### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,8 @@ jobs:
   build-and-deploy:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: 📥 Checkout repo


### PR DESCRIPTION
Potential fix for [https://github.com/BenjaminTietz/LeaseLoop_Frontend/security/code-scanning/1](https://github.com/BenjaminTietz/LeaseLoop_Frontend/security/code-scanning/1)

In general, fix this by explicitly defining a minimal `permissions:` block in the workflow so the `GITHUB_TOKEN` is restricted to only what the job actually needs. For this workflow, the job only checks out code, installs dependencies, builds, and deploys via FTP using secrets; it does not modify repository contents or GitHub resources, so `contents: read` is sufficient.

The best minimal fix without changing existing functionality is to add a job-level `permissions` block under `build-and-deploy:` in `.github/workflows/deploy.yml`. This makes the intent clear and ensures other workflows can still choose their own permissions. Specifically, on line 11–13 we will keep the existing `if:` and `runs-on:` lines and insert:

```yaml
    permissions:
      contents: read
```

indented to match job properties. No imports or other changes are required, and no steps need modification because none use `GITHUB_TOKEN` beyond the default read access required by `actions/checkout`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
